### PR TITLE
Add OpenTelemetryBuilder extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Jaahas.OpenTelemetry.Extensions makes it easy to configure an OpenTelemetry Prot
 // IConfiguration.
 
 services.AddOpenTelemetry()
-    .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly))
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
     // TODO: configure trace and metrics instrumentation.
     .AddOtlpExporter(configuration);
 ```
@@ -107,7 +107,7 @@ var exporterOptions = new JaahasOtlpExporterOptions() {
 };
 
 services.AddOpenTelemetry()
-    .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly))
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
     // TODO: configure trace and metrics instrumentation.
     .AddOtlpExporter(exporterOptions);
 ```
@@ -116,7 +116,7 @@ services.AddOpenTelemetry()
 // Configure exporter options manually via callback.
 
 services.AddOpenTelemetry()
-    .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly))
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
     // TODO: configure trace and metrics instrumentation.
     .AddOtlpExporter(exporterOptions => {
         exporterOptions.Enabled = true;

--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ When you construct your OpenTelemetry `ResourceBuilder`, you can easily register
 
 ```csharp
 services.AddOpenTelemetry()
-    .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly));
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly));
 ```
 
 This will register the service using the name specified in the attribute, and the version of the assembly in `MAJOR.MINOR.PATCH` format. You can also optionally specify a service instance ID:
 
 ```csharp
 services.AddOpenTelemetry()
-    .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly, "some-id"));
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly, "some-id"));
 ```
 
 
-# OpenTelemetry Protocol (OTLP) Exporter Configuration
+# Configuring a Multi-Signal OpenTelemetry Protocol (OTLP) Exporter
 
-Jaahas.OpenTelemetry.Extensions makes it easy to configure an OpenTelemetry Protocol (OTLP) exporter via the .NET configuration system. The exporter can be configured to export traces, metrics or logs, or any combination of the three:
+Jaahas.OpenTelemetry.Extensions makes it easy to configure an OpenTelemetry Protocol (OTLP) exporter via the .NET configuration system or by manually configuring exporter options. The exporter can be configured to export traces, metrics or logs, or any combination of the three:
 
 ```csharp
 // Assumes that configuration is an instance of your application's 
@@ -41,21 +41,11 @@ Jaahas.OpenTelemetry.Extensions makes it easy to configure an OpenTelemetry Prot
 
 services.AddOpenTelemetry()
     .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly))
-    .WithTracing(builder => {
-        // TODO: configure tracing
-        builder.ConfigureOtlpExporter(configuration);
-    })
-    .WithMetrics(builder => {
-        // TODO: configure metrics
-        builder.ConfigureOtlpExporter(configuration);
-    })
-    .WithLogging(configureBuilder: null, configureOptions: options => {
-        options.IncludeScopes = true;
-        options.ConfigureOtlpExporter(configuration);
-    });
+    // TODO: configure trace and metrics instrumentation.
+    .AddOtlpExporter(configuration);
 ```
 
-By default, the `ConfigureOtlpExporter` extension method will bind against a configuration section named `OpenTelemetry:Exporters:OTLP` to configure an instance of [JaahasOtlpExporterOptions](./Exporters/OpenTelemetryProtocol/JaahasOtlpExporterOptions.cs).
+By default, the `AddOtlpExporter` extension method will bind against a configuration section named `OpenTelemetry:Exporters:OTLP` to configure an instance of [JaahasOtlpExporterOptions](./src/Jaahas.OpenTelemetry.Extensions/Exporters/OpenTelemetryProtocol/JaahasOtlpExporterOptions.cs).
 
 The default configuration used is as follows:
 
@@ -103,12 +93,42 @@ The default configuration used is as follows:
 }
 ```
 
-Note that the default configuration means that the OTLP exporter is disabled by default and calls to the `ConfigureOtlpExporter` extension method have no effect until it is enabled.
+Note that the default configuration means that the OTLP exporter is disabled by default and calls to the `AddOtlpExporter` extension method have no effect until it is enabled.
+
+It is also possible to configure the exporter by providing your own `JaahasOtlpExporterOptions` instance, or by providing an `Action<JaahasOtlpExporterOptions>` that can be used to configure the options:
+
+```csharp
+// Configure exporter options manually.
+
+var exporterOptions = new JaahasOtlpExporterOptions() {
+    Enabled = true,
+    Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf,
+    Signals = OtlpExporterSignalKind.TracesAndLogs,
+};
+
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly))
+    // TODO: configure trace and metrics instrumentation.
+    .AddOtlpExporter(exporterOptions);
+```
+
+```csharp
+// Configure exporter options manually via callback.
+
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly))
+    // TODO: configure trace and metrics instrumentation.
+    .AddOtlpExporter(exporterOptions => {
+        exporterOptions.Enabled = true;
+        exporterOptions.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
+        exporterOptions.Signals = OtlpExporterSignalKind.TracesAndLogs;
+    });
+```
 
 
-## Example Configuration
+## Example Configuration: Seq
 
-To export logs and traces to [Seq](https://datalust.co/seq) using the HTTP protobuf export format, you could use the following configuration:
+[Seq](https://datalust.co/seq) can ingest OTLP traces and logs. To export these signals to a local Seq instance using the HTTP/Protobuf export format, you could use the following configuration:
 
 ```json
 {
@@ -127,6 +147,28 @@ To export logs and traces to [Seq](https://datalust.co/seq) using the HTTP proto
     }
 }
 ```
+
+
+## Example Configuration: Jaeger
+
+[Jaeger](https://www.jaegertracing.io/) can ingest OTLP traces. To export traces to a local Jaeger instance using the HTTP/Protobuf export format, you could use the following configuration:
+
+```json
+{
+    "OpenTelemetry": {
+        "Exporters": {
+            "OTLP": {
+                "Enabled": true,
+                "Protocol": "HttpProtobuf",
+                "Signals": "Traces"
+            }
+        }
+    }
+}
+```
+
+Jaeger's OTLP trace receivers listen on the standard OTLP exporter endpoints i.e. port 4317 for gRPC and port 4318 for HTTP/Protobuf. When the `Endpoint` setting is omitted from the configuration, the exporter will default to the standard port for the export format on `localhost`.
+
 
 
 # Building the Solution

--- a/build/version.json
+++ b/build/version.json
@@ -1,5 +1,5 @@
 {
-  "Major": 1,
+  "Major": 2,
   "Minor": 0,
   "Patch": 0,
   "PreRelease": ""

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryBuilderExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryBuilderExtensions.cs
@@ -1,0 +1,188 @@
+﻿using Jaahas.OpenTelemetry.Exporters.OpenTelemetryProtocol;
+
+using Microsoft.Extensions.Configuration;
+
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry {
+
+    /// <summary>
+    /// Extensions for <see cref="OpenTelemetryBuilder"/>.
+    /// </summary>
+    public static class JaahasOpenTelemetryBuilderExtensions {
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// <paramref name="configuration"/>.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="OpenTelemetryBuilder"/> to configure.
+        /// </param>
+        /// <param name="configuration">
+        ///   The <see cref="IConfiguration"/> containing the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configurationSectionName">
+        ///   The configuration section to bind the OTLP exporter configuration from. Specify 
+        ///   <see langword="null"/> or white space to bind directly against the root of the 
+        ///   <paramref name="configuration"/>.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///   
+        /// <para>
+        ///   The <paramref name="configuration"/> is used to configure an instance of 
+        ///   <see cref="JaahasOtlpExporterOptions"/>. By default, the <see cref="OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection"/> 
+        ///   configuration section is used. An alternative configuration section can be specified 
+        ///   using the <paramref name="configurationSectionName"/> parameter. Specify <see langword="null"/> 
+        ///   or white space to bind directly against the root of the <paramref name="configuration"/>.
+        /// </para>
+        /// 
+        /// <para>
+        ///   If the OLTP exporter is enabled, the exporter is automatically registered 
+        ///   for each signal that it is enabled for (traces, logs, and metrics).
+        /// </para>
+        /// 
+        /// </remarks>
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+#if NET8_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(configuration);
+#else
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (configuration == null) {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+#endif
+            var exporterOptions = new JaahasOtlpExporterOptions();
+
+            var configurationSection = string.IsNullOrWhiteSpace(configurationSectionName)
+                ? configuration
+                : configuration.GetSection(configurationSectionName!);
+
+            OtlpExporterConfigurationUtilities.Bind(exporterOptions, configurationSection);
+
+            return builder.AddOtlpExporter(exporterOptions);
+        }
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// delegate.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="OpenTelemetryBuilder"/> to configure.
+        /// </param>
+        /// <param name="configure">
+        ///   The delegate used to configure the OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///
+        /// <para>
+        ///   If the OLTP exporter is enabled, the exporter is automatically registered
+        ///   for each signal that it is enabled for (traces, logs, and metrics).
+        /// </para>
+        /// 
+        /// </remarks>
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, Action<JaahasOtlpExporterOptions> configure) {
+#if NET8_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(configure);
+#else
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (configure == null) {
+                throw new ArgumentNullException(nameof(configure));
+            }
+#endif
+
+            var exporterOptions = new JaahasOtlpExporterOptions();
+            configure.Invoke(exporterOptions);
+
+            return builder.AddOtlpExporter(exporterOptions);
+        }
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// options.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="OpenTelemetryBuilder"/> to configure.
+        /// </param>
+        /// <param name="options">
+        ///   The OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///
+        /// <para>
+        ///   If the OLTP exporter is enabled, the exporter is automatically registered 
+        ///   for each signal that it is enabled for (traces, logs, and metrics).
+        /// </para>
+        /// 
+        /// </remarks>
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, JaahasOtlpExporterOptions options) {
+#if NET8_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(options);
+#else
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+#endif
+
+            if (!options.Enabled) {
+                return builder;
+            }
+
+            if (options.Signals.HasFlag(OtlpExporterSignalKind.Traces)) {
+                builder.WithTracing(builder => builder.AddOtlpExporter(options));
+            }
+            if (options.Signals.HasFlag(OtlpExporterSignalKind.Metrics)) {
+                builder.WithMetrics(builder => builder.AddOtlpExporter(options));
+            }
+            if (options.Signals.HasFlag(OtlpExporterSignalKind.Logs)) {
+                builder.WithLogging(configureBuilder: null, configureOptions: builder => {
+                    builder.IncludeScopes = true;
+                    builder.AddOtlpExporter(options);
+                });
+            }
+
+            return builder;
+        }
+
+    }
+}

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryLogExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryLogExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using Jaahas.OpenTelemetry.Exporters.OpenTelemetryProtocol;
 
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
 
 namespace OpenTelemetry.Logs {
 
@@ -11,73 +10,123 @@ namespace OpenTelemetry.Logs {
     public static class JaahasOpenTelemetryLogExtensions {
 
         /// <summary>
-        /// Adds an OLTP exporter if it is enabled in the provided <paramref name="configuration"/>.
+        /// Adds an OLTP exporter that is configured using the provided <paramref name="configuration"/>.
         /// </summary>
-        /// <param name="options">
+        /// <param name="loggerOptions">
         ///   The <see cref="OpenTelemetryLoggerOptions"/> to configure.
         /// </param>
         /// <param name="configuration">
         ///   The <see cref="IConfiguration"/> containing the OTLP exporter configuration.
         /// </param>
         /// <param name="configurationSectionName">
-        ///   The configuration section to bind the OTLP exporter configuration from. If 
-        ///   <see langword="null"/>, the root <paramref name="configuration"/> is used.
+        ///   The configuration section to bind the OTLP exporter configuration from. Specify 
+        ///   <see langword="null"/> or white space to bind directly against the root of the 
+        ///   <paramref name="configuration"/>.
         /// </param>
         /// <returns>
         ///   The updated <see cref="OpenTelemetryLoggerOptions"/>.
         /// </returns>
-        public static OpenTelemetryLoggerOptions ConfigureOtlpExporter(this OpenTelemetryLoggerOptions options, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="loggerOptions"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
 #if NET8_0_OR_GREATER
-            ArgumentNullException.ThrowIfNull(options);
+            ArgumentNullException.ThrowIfNull(loggerOptions);
             ArgumentNullException.ThrowIfNull(configuration);
 #else 
-            if (options == null) {
-                throw new ArgumentNullException(nameof(options));
+            if (loggerOptions == null) {
+                throw new ArgumentNullException(nameof(loggerOptions));
             }
             if (configuration == null) {
                 throw new ArgumentNullException(nameof(configuration));
             }
 #endif
-            var exporterOptions = new JaahasOtlpExporterOptions();
+            var options = new JaahasOtlpExporterOptions();
 
             var configurationSection = string.IsNullOrWhiteSpace(configurationSectionName) 
                 ? configuration 
                 : configuration.GetSection(configurationSectionName!);
 
-            OtlpExporterConfigurationUtilities.Bind(exporterOptions, configurationSection);
+            OtlpExporterConfigurationUtilities.Bind(options, configurationSection);
 
-            return options.ConfigureOtlpExporter(exporterOptions);
+            return loggerOptions.AddOtlpExporter(options);
         }
 
 
         /// <summary>
-        /// Adds an OLTP exporter if it is enabled in the provided exporter options.
+        /// Adds an OLTP exporter that is configured using the provided delegate.
         /// </summary>
-        /// <param name="options">
+        /// <param name="loggerOptions">
         ///   The <see cref="OpenTelemetryLoggerOptions"/> to configure.
         /// </param>
-        /// <param name="exporterOptions">
+        /// <param name="configure">
+        ///   The delegate used to configure the OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryLoggerOptions"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="loggerOptions"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, Action<JaahasOtlpExporterOptions> configure) {
+#if NET8_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(loggerOptions);
+            ArgumentNullException.ThrowIfNull(configure);
+#else
+            if (loggerOptions == null) {
+                throw new ArgumentNullException(nameof(loggerOptions));
+            }
+            if (configure == null) {
+                throw new ArgumentNullException(nameof(configure));
+            }
+#endif
+
+            var options = new JaahasOtlpExporterOptions();
+            configure.Invoke(options);
+
+            return loggerOptions.AddOtlpExporter(options);
+        }
+
+
+        /// <summary>
+        /// Adds an OLTP exporter that is configured using the provided options.
+        /// </summary>
+        /// <param name="loggerOptions">
+        ///   The <see cref="OpenTelemetryLoggerOptions"/> to configure.
+        /// </param>
+        /// <param name="options">
         ///   The exporter options.
         /// </param>
         /// <returns>
         ///   The updated <see cref="OpenTelemetryLoggerOptions"/>.
         /// </returns>
-        public static OpenTelemetryLoggerOptions ConfigureOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, JaahasOtlpExporterOptions exporterOptions) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="loggerOptions"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, JaahasOtlpExporterOptions options) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(loggerOptions);
-            ArgumentNullException.ThrowIfNull(exporterOptions);
+            ArgumentNullException.ThrowIfNull(options);
 #else
             if (loggerOptions == null) {
                 throw new ArgumentNullException(nameof(loggerOptions));
             }
-            if (exporterOptions == null) {
-                throw new ArgumentNullException(nameof(exporterOptions));
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
             }
 #endif
 
-
-            if (exporterOptions.Enabled && exporterOptions.Signals.HasFlag(OtlpExporterSignalKind.Logs)) {
-                loggerOptions.AddOtlpExporter(opts => OtlpExporterConfigurationUtilities.ConfigureOtlpExporterOptions(opts, exporterOptions, OtlpExporterSignalKind.Logs));
+            if (options.Enabled && options.Signals.HasFlag(OtlpExporterSignalKind.Logs)) {
+                loggerOptions.AddOtlpExporter(opts => OtlpExporterConfigurationUtilities.ConfigureOtlpExporterOptions(opts, options, OtlpExporterSignalKind.Logs));
             }
 
             return loggerOptions;

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryMetricExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryMetricExtensions.cs
@@ -2,9 +2,7 @@
 
 using Microsoft.Extensions.Configuration;
 
-using OpenTelemetry.Metrics;
-
-namespace OpenTelemetry.Trace {
+namespace OpenTelemetry.Metrics {
 
     /// <summary>
     /// Extensions for OpenTelemetry metrics configuration.
@@ -12,7 +10,8 @@ namespace OpenTelemetry.Trace {
     public static class JaahasOpenTelemetryMetricExtensions {
 
         /// <summary>
-        /// Adds an OLTP exporter if it is enabled in the provided <paramref name="configuration"/>.
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// <paramref name="configuration"/>.
         /// </summary>
         /// <param name="builder">
         ///   The <see cref="MeterProviderBuilder"/> to configure.
@@ -21,13 +20,20 @@ namespace OpenTelemetry.Trace {
         ///   The <see cref="IConfiguration"/> containing the OTLP exporter configuration.
         /// </param>
         /// <param name="configurationSectionName">
-        ///   The configuration section to bind the OTLP exporter configuration from. If 
-        ///   <see langword="null"/>, the root <paramref name="configuration"/> is used.
+        ///   The configuration section to bind the OTLP exporter configuration from. Specify 
+        ///   <see langword="null"/> or white space to bind directly against the root of the 
+        ///   <paramref name="configuration"/>.
         /// </param>
         /// <returns>
         ///   The updated <see cref="MeterProviderBuilder"/>.
         /// </returns>
-        public static MeterProviderBuilder ConfigureOtlpExporter(this MeterProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configuration);
@@ -48,12 +54,52 @@ namespace OpenTelemetry.Trace {
 
             OtlpExporterConfigurationUtilities.Bind(options, configurationSection);
 
-            return builder.ConfigureOtlpExporter(options);
+            return builder.AddOtlpExporter(options);
         }
 
 
         /// <summary>
-        /// Adds an OLTP exporter if it is enabled in the provided exporter options.
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// delehate.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="MeterProviderBuilder"/> to configure.
+        /// </param>
+        /// <param name="configure">
+        ///   The delegate used to configure the OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="MeterProviderBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, Action<JaahasOtlpExporterOptions> configure) {
+#if NET8_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(configure);
+#else 
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (configure == null) {
+                throw new ArgumentNullException(nameof(configure));
+            }
+#endif
+
+            var options = new JaahasOtlpExporterOptions();
+            configure.Invoke(options);
+
+            return builder.AddOtlpExporter(options);
+        }
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// options.
         /// </summary>
         /// <param name="builder">
         ///   The <see cref="MeterProviderBuilder"/> to configure.
@@ -64,7 +110,13 @@ namespace OpenTelemetry.Trace {
         /// <returns>
         ///   The updated <see cref="MeterProviderBuilder"/>.
         /// </returns>
-        public static MeterProviderBuilder ConfigureOtlpExporter(this MeterProviderBuilder builder, JaahasOtlpExporterOptions options) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, JaahasOtlpExporterOptions options) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(options);

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryResourceBuilderExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryResourceBuilderExtensions.cs
@@ -2,8 +2,6 @@
 
 using Jaahas.OpenTelemetry;
 
-using Microsoft.Extensions.Configuration;
-
 namespace OpenTelemetry.Resources {
 
     /// <summary>

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryTraceExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryTraceExtensions.cs
@@ -10,7 +10,8 @@ namespace OpenTelemetry.Trace {
     public static class JaahasOpenTelemetryTraceExtensions {
 
         /// <summary>
-        /// Adds an OLTP exporter if it is enabled in the provided <paramref name="configuration"/>.
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// <paramref name="configuration"/>.
         /// </summary>
         /// <param name="builder">
         ///   The <see cref="TracerProviderBuilder"/> to configure.
@@ -19,13 +20,20 @@ namespace OpenTelemetry.Trace {
         ///   The <see cref="IConfiguration"/> containing the OTLP exporter configuration.
         /// </param>
         /// <param name="configurationSectionName">
-        ///   The configuration section to bind the OTLP exporter configuration from. If 
-        ///   <see langword="null"/>, the root <paramref name="configuration"/> is used.
+        ///   The configuration section to bind the OTLP exporter configuration from. Specify 
+        ///   <see langword="null"/> or white space to bind directly against the root of the 
+        ///   <paramref name="configuration"/>.
         /// </param>
         /// <returns>
         ///   The updated <see cref="TracerProviderBuilder"/>.
         /// </returns>
-        public static TracerProviderBuilder ConfigureOtlpExporter(this TracerProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configuration);
@@ -46,23 +54,69 @@ namespace OpenTelemetry.Trace {
 
             OtlpExporterConfigurationUtilities.Bind(options, configurationSection);
 
-            return builder.ConfigureExporter(options);
+            return builder.AddOtlpExporter(options);
         }
 
 
         /// <summary>
-        /// Adds an OLTP exporter if it is enabled in the provided exporter options.
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// delegate.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="TracerProviderBuilder"/> to configure.
+        /// </param>
+        /// <param name="configure">
+        ///   The delegate used to configure the OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TracerProviderBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, Action<JaahasOtlpExporterOptions> configure) {
+#if NET8_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(configure);
+#else 
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (configure == null) {
+                throw new ArgumentNullException(nameof(configure));
+            }
+#endif
+
+            var options = new JaahasOtlpExporterOptions();
+            configure.Invoke(options);
+
+            return builder.AddOtlpExporter(options);
+        }
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// options.
         /// </summary>
         /// <param name="builder">
         ///   The <see cref="TracerProviderBuilder"/> to configure.
         /// </param>
         /// <param name="options">
-        ///   The exporter options.
+        ///   The OTLP exporter options.
         /// </param>
         /// <returns>
         ///   The updated <see cref="TracerProviderBuilder"/>.
         /// </returns>
-        public static TracerProviderBuilder ConfigureExporter(this TracerProviderBuilder builder, JaahasOtlpExporterOptions options) {
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, JaahasOtlpExporterOptions options) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(options);

--- a/src/Jaahas.OpenTelemetry.Extensions/README.md
+++ b/src/Jaahas.OpenTelemetry.Extensions/README.md
@@ -35,7 +35,7 @@ Jaahas.OpenTelemetry.Extensions makes it easy to configure an OpenTelemetry Prot
 // IConfiguration.
 
 services.AddOpenTelemetry()
-    .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly))
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
     // TODO: configure trace and metrics instrumentation.
     .AddOtlpExporter(configuration);
 ```
@@ -102,7 +102,7 @@ var exporterOptions = new JaahasOtlpExporterOptions() {
 };
 
 services.AddOpenTelemetry()
-    .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly))
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
     // TODO: configure trace and metrics instrumentation.
     .AddOtlpExporter(exporterOptions);
 ```
@@ -111,7 +111,7 @@ services.AddOpenTelemetry()
 // Configure exporter options manually via callback.
 
 services.AddOpenTelemetry()
-    .ConfigureResource(builder => builder.AddService(typeof(MyServiceType).Assembly))
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
     // TODO: configure trace and metrics instrumentation.
     .AddOtlpExporter(exporterOptions => {
         exporterOptions.Enabled = true;


### PR DESCRIPTION
This PR adds extension methods for the main `OpenTelemetryBuilder` class that allow an OTLP exporter to be configured without having to explicitly register the exporter in individual calls to `WithTracing`, `WithMetrics` and `WithLogging`.

The PR also contains breaking changes, as various extension methods named `ConfigureOtlpExporter` have now been renamed to `AddOtlpExporter`.