### PR TITLE
Named OTLP exporters

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.11.1" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />

--- a/Jaahas.OpenTelemetry.sln
+++ b/Jaahas.OpenTelemetry.sln
@@ -25,7 +25,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{ADFADB4B-0
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{9EC81ADF-5CE2-4140-96BC-958CB9E0365C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jaahas.OpenTelemetry.Extensions", "src\Jaahas.OpenTelemetry.Extensions\Jaahas.OpenTelemetry.Extensions.csproj", "{6DF95504-2089-4537-9C56-2414465BFCA0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jaahas.OpenTelemetry.Extensions", "src\Jaahas.OpenTelemetry.Extensions\Jaahas.OpenTelemetry.Extensions.csproj", "{6DF95504-2089-4537-9C56-2414465BFCA0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultipleDestinationOtlpExporterExample", "samples\MultipleDestinationOtlpExporterExample\MultipleDestinationOtlpExporterExample.csproj", "{DF72DB5E-3376-4295-BD78-95C26B37433E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtlpExporterExample", "samples\OtlpExporterExample\OtlpExporterExample.csproj", "{BF201C92-6C05-431E-A805-FFF1A719356A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,12 +41,22 @@ Global
 		{6DF95504-2089-4537-9C56-2414465BFCA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6DF95504-2089-4537-9C56-2414465BFCA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6DF95504-2089-4537-9C56-2414465BFCA0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF72DB5E-3376-4295-BD78-95C26B37433E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF72DB5E-3376-4295-BD78-95C26B37433E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF72DB5E-3376-4295-BD78-95C26B37433E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF72DB5E-3376-4295-BD78-95C26B37433E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF201C92-6C05-431E-A805-FFF1A719356A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF201C92-6C05-431E-A805-FFF1A719356A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF201C92-6C05-431E-A805-FFF1A719356A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF201C92-6C05-431E-A805-FFF1A719356A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{6DF95504-2089-4537-9C56-2414465BFCA0} = {10A2813D-C970-4F6F-9A59-94F7C972257F}
+		{DF72DB5E-3376-4295-BD78-95C26B37433E} = {9EC81ADF-5CE2-4140-96BC-958CB9E0365C}
+		{BF201C92-6C05-431E-A805-FFF1A719356A} = {9EC81ADF-5CE2-4140-96BC-958CB9E0365C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {94DF2EE3-033D-46CD-9EC3-7BC808B13372}

--- a/README.md
+++ b/README.md
@@ -170,6 +170,49 @@ services.AddOpenTelemetry()
 Jaeger's OTLP trace receivers listen on the standard OTLP exporter endpoints i.e. port 4317 for gRPC and port 4318 for HTTP/Protobuf. When the `Endpoint` setting is omitted from the configuration, the exporter will default to the standard port for the export format on `localhost`.
 
 
+## Configuring Multiple Exporters
+
+You can also configure multiple named exporters by providing a name to the `AddOtlpExporter` extension method. For example, if you wanted to export logs to Seq and traces to Jaeger:
+
+```csharp
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
+    // TODO: configure trace and metrics instrumentation.
+    .AddOtlpExporter("seq", 
+        configuration, 
+        configurationSectionName: "OpenTelemetry:Exporters:OTLP:Seq")
+    .AddOtlpExporter("jaeger", 
+        configuration, 
+        configurationSectionName: "OpenTelemetry:Exporters:OTLP:Jaeger");
+```
+
+You would then configure the exporters in your `appsettings.json` file as follows:
+
+```json
+{
+    "OpenTelemetry": {
+        "Exporters": {
+            "OTLP": {
+                "Seq": {
+                    "Enabled": true,
+                    "Protocol": "HttpProtobuf",
+                    "Endpoint": "http://localhost:5341/ingest/otlp",
+                    "Signals": "Logs",
+                    "Headers": {
+                        "X-Seq-ApiKey": "your-api-key"
+                    }
+                },
+                "Jaeger": {
+                    "Enabled": true,
+                    "Protocol": "HttpProtobuf",
+                    "Signals": "Traces"
+                }
+            }
+        }
+    }
+}
+```
+
 
 # Building the Solution
 

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 0,
-  "Patch": 2,
+  "Minor": 1,
+  "Patch": 0,
   "PreRelease": ""
 }

--- a/samples/MultipleDestinationOtlpExporterExample/MultipleDestinationOtlpExporterExample.csproj
+++ b/samples/MultipleDestinationOtlpExporterExample/MultipleDestinationOtlpExporterExample.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-MultipleDestinationOtlpExporterExample-c4a3c907-7e9f-4056-9c6c-3b211f3dd571</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Jaahas.OpenTelemetry.Extensions\Jaahas.OpenTelemetry.Extensions.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/MultipleDestinationOtlpExporterExample/Program.cs
+++ b/samples/MultipleDestinationOtlpExporterExample/Program.cs
@@ -1,0 +1,18 @@
+﻿using MultipleDestinationOtlpExporterExample;
+
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
+
+// Note that both exporters actually export to the same destination in this example, but they
+// export different signal types. See appsettings.json for the configuration.
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService("MultipleDestinationOtlpExporterExample"))
+    .AddOtlpExporter("seq-traces", builder.Configuration, "OpenTelemetry:Exporters:OTLP:SeqTraces")
+    .AddOtlpExporter("seq-logs", builder.Configuration, "OpenTelemetry:Exporters:OTLP:SeqLogs")
+    .WithTracing(tracing => tracing.AddSource(Worker.ActivitySourceName));
+
+var host = builder.Build();
+host.Run();

--- a/samples/MultipleDestinationOtlpExporterExample/Properties/launchSettings.json
+++ b/samples/MultipleDestinationOtlpExporterExample/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "MultipleDestinationOtlpExporterExample": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/MultipleDestinationOtlpExporterExample/Worker.cs
+++ b/samples/MultipleDestinationOtlpExporterExample/Worker.cs
@@ -1,0 +1,30 @@
+﻿using System.Diagnostics;
+
+namespace MultipleDestinationOtlpExporterExample {
+    public class Worker : BackgroundService {
+
+        public const string ActivitySourceName = "MultipleDestinationOtlpExporterExample";
+
+        private readonly ILogger<Worker> _logger;
+
+        private readonly ActivitySource _activitySource = new ActivitySource(ActivitySourceName);
+
+
+        public Worker(ILogger<Worker> logger) {
+            _logger = logger;
+        }
+
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
+            while (!stoppingToken.IsCancellationRequested) {
+                using var activity = _activitySource.StartActivity("WorkerActivity");
+
+                if (_logger.IsEnabled(LogLevel.Information)) {
+                    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                }
+
+                await Task.Delay(1000, stoppingToken);
+            }
+        }
+    }
+}

--- a/samples/MultipleDestinationOtlpExporterExample/appsettings.Development.json
+++ b/samples/MultipleDestinationOtlpExporterExample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/samples/MultipleDestinationOtlpExporterExample/appsettings.json
+++ b/samples/MultipleDestinationOtlpExporterExample/appsettings.json
@@ -1,0 +1,26 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "OpenTelemetry": {
+    "Exporters": {
+      "OTLP": {
+        "SeqLogs": {
+          "Enabled": true,
+          "Protocol": "HttpProtobuf",
+          "Endpoint": "http://localhost:5341/ingest/otlp",
+          "Signals": "Logs"
+        },
+        "SeqTraces": {
+          "Enabled": true,
+          "Protocol": "HttpProtobuf",
+          "Endpoint": "http://localhost:5341/ingest/otlp",
+          "Signals": "Traces"
+        }
+      }
+    }
+  }
+}

--- a/samples/OtlpExporterExample/OtlpExporterExample.csproj
+++ b/samples/OtlpExporterExample/OtlpExporterExample.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-OtlpExporterExample-f33f16c8-19b7-4176-ae30-2d643cf647cc</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Jaahas.OpenTelemetry.Extensions\Jaahas.OpenTelemetry.Extensions.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/OtlpExporterExample/Program.cs
+++ b/samples/OtlpExporterExample/Program.cs
@@ -1,0 +1,15 @@
+﻿using OtlpExporterExample;
+
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
+
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService("OtlpExporterExample"))
+    .AddOtlpExporter(builder.Configuration)
+    .WithTracing(tracing => tracing.AddSource(Worker.ActivitySourceName));
+
+var host = builder.Build();
+host.Run();

--- a/samples/OtlpExporterExample/Properties/launchSettings.json
+++ b/samples/OtlpExporterExample/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "OtlpExporterExample": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/OtlpExporterExample/Worker.cs
+++ b/samples/OtlpExporterExample/Worker.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics;
+
+namespace OtlpExporterExample {
+    public class Worker : BackgroundService {
+        public const string ActivitySourceName = "OtlpExporterExample";
+
+        private readonly ILogger<Worker> _logger;
+
+        private readonly ActivitySource _activitySource = new ActivitySource(ActivitySourceName);
+
+
+        public Worker(ILogger<Worker> logger) {
+            _logger = logger;
+        }
+
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
+            while (!stoppingToken.IsCancellationRequested) {
+                using var activity = _activitySource.StartActivity("WorkerActivity");
+
+                if (_logger.IsEnabled(LogLevel.Information)) {
+                    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                }
+
+                await Task.Delay(1000, stoppingToken);
+            }
+        }
+    }
+}

--- a/samples/OtlpExporterExample/appsettings.Development.json
+++ b/samples/OtlpExporterExample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/samples/OtlpExporterExample/appsettings.json
+++ b/samples/OtlpExporterExample/appsettings.json
@@ -1,0 +1,18 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "OpenTelemetry": {
+    "Exporters": {
+      "OTLP": {
+        "Enabled": true,
+        "Protocol": "HttpProtobuf",
+        "Endpoint": "http://localhost:5341/ingest/otlp",
+        "Signals": "TracesAndLogs"
+      }
+    }
+  }
+}

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryBuilderExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Jaahas.OpenTelemetry.Exporters.OpenTelemetryProtocol;
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
@@ -53,7 +54,54 @@ namespace OpenTelemetry {
         /// </para>
         /// 
         /// </remarks>
-        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) 
+            => builder.AddOtlpExporter(null, configuration, configurationSectionName);
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// <paramref name="configuration"/>.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="OpenTelemetryBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configuration">
+        ///   The <see cref="IConfiguration"/> containing the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configurationSectionName">
+        ///   The configuration section to bind the OTLP exporter configuration from. Specify 
+        ///   <see langword="null"/> or white space to bind directly against the root of the 
+        ///   <paramref name="configuration"/>.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///   
+        /// <para>
+        ///   The <paramref name="configuration"/> is used to configure an instance of 
+        ///   <see cref="JaahasOtlpExporterOptions"/>. By default, the <see cref="OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection"/> 
+        ///   configuration section is used. An alternative configuration section can be specified 
+        ///   using the <paramref name="configurationSectionName"/> parameter. Specify <see langword="null"/> 
+        ///   or white space to bind directly against the root of the <paramref name="configuration"/>.
+        /// </para>
+        /// 
+        /// <para>
+        ///   If the OLTP exporter is enabled, the exporter is automatically registered 
+        ///   for each signal that it is enabled for (traces, logs, and metrics).
+        /// </para>
+        /// 
+        /// </remarks>
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configuration);
@@ -70,7 +118,7 @@ namespace OpenTelemetry {
                 ? configuration
                 : configuration.GetSection(configurationSectionName!);
 
-            return builder.AddOtlpExporter(options => OtlpExporterConfigurationUtilities.Bind(options, configurationSection));
+            return builder.AddOtlpExporter(name, options => OtlpExporterConfigurationUtilities.Bind(options, configurationSection));
         }
 
 
@@ -101,7 +149,41 @@ namespace OpenTelemetry {
         /// </para>
         /// 
         /// </remarks>
-        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, Action<JaahasOtlpExporterOptions> configure) {
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, Action<JaahasOtlpExporterOptions> configure) 
+            => builder.AddOtlpExporter(null, configure);
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// delegate.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="OpenTelemetryBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configure">
+        ///   The delegate used to configure the OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///
+        /// <para>
+        ///   If the OLTP exporter is enabled, the exporter is automatically registered
+        ///   for each signal that it is enabled for (traces, logs, and metrics).
+        /// </para>
+        /// 
+        /// </remarks>
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, string? name, Action<JaahasOtlpExporterOptions> configure) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configure);
@@ -117,8 +199,9 @@ namespace OpenTelemetry {
             var exporterOptions = new JaahasOtlpExporterOptions();
             configure.Invoke(exporterOptions);
 
-            return builder.AddOtlpExporter(exporterOptions);
+            return builder.AddOtlpExporter(name, exporterOptions);
         }
+
 
 
         /// <summary>
@@ -148,7 +231,41 @@ namespace OpenTelemetry {
         /// </para>
         /// 
         /// </remarks>
-        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, JaahasOtlpExporterOptions options) {
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, JaahasOtlpExporterOptions options) 
+            => builder.AddOtlpExporter(null, options);
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// options.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="OpenTelemetryBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="options">
+        ///   The OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///
+        /// <para>
+        ///   If the OLTP exporter is enabled, the exporter is automatically registered 
+        ///   for each signal that it is enabled for (traces, logs, and metrics).
+        /// </para>
+        /// 
+        /// </remarks>
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, string? name, JaahasOtlpExporterOptions options) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(options);
@@ -166,15 +283,15 @@ namespace OpenTelemetry {
             }
 
             if (options.Signals.HasFlag(OtlpExporterSignalKind.Traces)) {
-                builder.WithTracing(builder => builder.AddOtlpExporter(options));
+                builder.WithTracing(builder => builder.AddOtlpExporter(name, options));
             }
             if (options.Signals.HasFlag(OtlpExporterSignalKind.Metrics)) {
-                builder.WithMetrics(builder => builder.AddOtlpExporter(options));
+                builder.WithMetrics(builder => builder.AddOtlpExporter(name, options));
             }
             if (options.Signals.HasFlag(OtlpExporterSignalKind.Logs)) {
                 builder.WithLogging(configureBuilder: null, configureOptions: builder => {
                     builder.IncludeScopes = true;
-                    builder.AddOtlpExporter(options);
+                    builder.AddOtlpExporter(name, options);
                 });
             }
 

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryLogExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryLogExtensions.cs
@@ -32,7 +32,37 @@ namespace OpenTelemetry.Logs {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configuration"/> is <see langword="null"/>.
         /// </exception>
-        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) 
+            => loggerOptions.AddOtlpExporter(null, configuration, configurationSectionName);
+
+
+        /// <summary>
+        /// Adds an OLTP exporter that is configured using the provided <paramref name="configuration"/>.
+        /// </summary>
+        /// <param name="loggerOptions">
+        ///   The <see cref="OpenTelemetryLoggerOptions"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configuration">
+        ///   The <see cref="IConfiguration"/> containing the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configurationSectionName">
+        ///   The configuration section to bind the OTLP exporter configuration from. Specify 
+        ///   <see langword="null"/> or white space to bind directly against the root of the 
+        ///   <paramref name="configuration"/>.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryLoggerOptions"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="loggerOptions"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(loggerOptions);
             ArgumentNullException.ThrowIfNull(configuration);
@@ -46,13 +76,13 @@ namespace OpenTelemetry.Logs {
 #endif
             var options = new JaahasOtlpExporterOptions();
 
-            var configurationSection = string.IsNullOrWhiteSpace(configurationSectionName) 
-                ? configuration 
+            var configurationSection = string.IsNullOrWhiteSpace(configurationSectionName)
+                ? configuration
                 : configuration.GetSection(configurationSectionName!);
 
             OtlpExporterConfigurationUtilities.Bind(options, configurationSection);
 
-            return loggerOptions.AddOtlpExporter(options);
+            return loggerOptions.AddOtlpExporter(name, options);
         }
 
 
@@ -74,7 +104,32 @@ namespace OpenTelemetry.Logs {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configure"/> is <see langword="null"/>.
         /// </exception>
-        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, Action<JaahasOtlpExporterOptions> configure) {
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, Action<JaahasOtlpExporterOptions> configure) 
+            => loggerOptions.AddOtlpExporter(null, configure);
+
+
+        /// <summary>
+        /// Adds an OLTP exporter that is configured using the provided delegate.
+        /// </summary>
+        /// <param name="loggerOptions">
+        ///   The <see cref="OpenTelemetryLoggerOptions"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configure">
+        ///   The delegate used to configure the OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryLoggerOptions"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="loggerOptions"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, string? name, Action<JaahasOtlpExporterOptions> configure) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(loggerOptions);
             ArgumentNullException.ThrowIfNull(configure);
@@ -90,7 +145,7 @@ namespace OpenTelemetry.Logs {
             var options = new JaahasOtlpExporterOptions();
             configure.Invoke(options);
 
-            return loggerOptions.AddOtlpExporter(options);
+            return loggerOptions.AddOtlpExporter(name, options);
         }
 
 
@@ -112,7 +167,32 @@ namespace OpenTelemetry.Logs {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="options"/> is <see langword="null"/>.
         /// </exception>
-        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, JaahasOtlpExporterOptions options) {
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, JaahasOtlpExporterOptions options) 
+            => loggerOptions.AddOtlpExporter(null, options);
+
+
+        /// <summary>
+        /// Adds an OLTP exporter that is configured using the provided options.
+        /// </summary>
+        /// <param name="loggerOptions">
+        ///   The <see cref="OpenTelemetryLoggerOptions"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="options">
+        ///   The exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryLoggerOptions"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="loggerOptions"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, string? name, JaahasOtlpExporterOptions options) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(loggerOptions);
             ArgumentNullException.ThrowIfNull(options);
@@ -126,7 +206,7 @@ namespace OpenTelemetry.Logs {
 #endif
 
             if (options.Enabled && options.Signals.HasFlag(OtlpExporterSignalKind.Logs)) {
-                loggerOptions.AddOtlpExporter(opts => OtlpExporterConfigurationUtilities.ConfigureOtlpExporterOptions(opts, options, OtlpExporterSignalKind.Logs));
+                loggerOptions.AddOtlpExporter(name, opts => OtlpExporterConfigurationUtilities.ConfigureOtlpExporterOptions(opts, options, OtlpExporterSignalKind.Logs));
             }
 
             return loggerOptions;

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryMetricExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryMetricExtensions.cs
@@ -33,7 +33,38 @@ namespace OpenTelemetry.Metrics {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configuration"/> is <see langword="null"/>.
         /// </exception>
-        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection)
+            => builder.AddOtlpExporter(null, configuration, configurationSectionName);
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// <paramref name="configuration"/>.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="MeterProviderBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configuration">
+        ///   The <see cref="IConfiguration"/> containing the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configurationSectionName">
+        ///   The configuration section to bind the OTLP exporter configuration from. Specify 
+        ///   <see langword="null"/> or white space to bind directly against the root of the 
+        ///   <paramref name="configuration"/>.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="MeterProviderBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configuration);
@@ -54,7 +85,7 @@ namespace OpenTelemetry.Metrics {
 
             OtlpExporterConfigurationUtilities.Bind(options, configurationSection);
 
-            return builder.AddOtlpExporter(options);
+            return builder.AddOtlpExporter(name, options);
         }
 
 
@@ -77,7 +108,33 @@ namespace OpenTelemetry.Metrics {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configure"/> is <see langword="null"/>.
         /// </exception>
-        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, Action<JaahasOtlpExporterOptions> configure) {
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, Action<JaahasOtlpExporterOptions> configure)
+            => builder.AddOtlpExporter(null, configure);
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// delehate.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="MeterProviderBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configure">
+        ///   The delegate used to configure the OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="MeterProviderBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, string? name, Action<JaahasOtlpExporterOptions> configure) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configure);
@@ -93,7 +150,7 @@ namespace OpenTelemetry.Metrics {
             var options = new JaahasOtlpExporterOptions();
             configure.Invoke(options);
 
-            return builder.AddOtlpExporter(options);
+            return builder.AddOtlpExporter(name, options);
         }
 
 
@@ -116,7 +173,33 @@ namespace OpenTelemetry.Metrics {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="options"/> is <see langword="null"/>.
         /// </exception>
-        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, JaahasOtlpExporterOptions options) {
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, JaahasOtlpExporterOptions options)
+            => builder.AddOtlpExporter(null, options);
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// options.
+        /// </summary>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="builder">
+        ///   The <see cref="MeterProviderBuilder"/> to configure.
+        /// </param>
+        /// <param name="options">
+        ///   The exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="MeterProviderBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, string? name, JaahasOtlpExporterOptions options) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(options);
@@ -130,7 +213,7 @@ namespace OpenTelemetry.Metrics {
 #endif
 
             if (options.Enabled && options.Signals.HasFlag(OtlpExporterSignalKind.Metrics)) {
-                builder.AddOtlpExporter(opts => OtlpExporterConfigurationUtilities.ConfigureOtlpExporterOptions(opts, options, OtlpExporterSignalKind.Metrics));
+                builder.AddOtlpExporter(name, opts => OtlpExporterConfigurationUtilities.ConfigureOtlpExporterOptions(opts, options, OtlpExporterSignalKind.Metrics));
             }
 
             return builder;

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryTraceExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryTraceExtensions.cs
@@ -33,7 +33,38 @@ namespace OpenTelemetry.Trace {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configuration"/> is <see langword="null"/>.
         /// </exception>
-        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) 
+            => builder.AddOtlpExporter(null, configuration, configurationSectionName);
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// <paramref name="configuration"/>.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="TracerProviderBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configuration">
+        ///   The <see cref="IConfiguration"/> containing the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configurationSectionName">
+        ///   The configuration section to bind the OTLP exporter configuration from. Specify 
+        ///   <see langword="null"/> or white space to bind directly against the root of the 
+        ///   <paramref name="configuration"/>.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TracerProviderBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configuration);
@@ -54,7 +85,7 @@ namespace OpenTelemetry.Trace {
 
             OtlpExporterConfigurationUtilities.Bind(options, configurationSection);
 
-            return builder.AddOtlpExporter(options);
+            return builder.AddOtlpExporter(name, options);
         }
 
 
@@ -77,7 +108,33 @@ namespace OpenTelemetry.Trace {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configure"/> is <see langword="null"/>.
         /// </exception>
-        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, Action<JaahasOtlpExporterOptions> configure) {
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, Action<JaahasOtlpExporterOptions> configure) 
+            => builder.AddOtlpExporter(null, configure);
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// delegate.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="TracerProviderBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="configure">
+        ///   The delegate used to configure the OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TracerProviderBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, string? name, Action<JaahasOtlpExporterOptions> configure) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configure);
@@ -93,7 +150,7 @@ namespace OpenTelemetry.Trace {
             var options = new JaahasOtlpExporterOptions();
             configure.Invoke(options);
 
-            return builder.AddOtlpExporter(options);
+            return builder.AddOtlpExporter(name, options);
         }
 
 
@@ -116,7 +173,33 @@ namespace OpenTelemetry.Trace {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="options"/> is <see langword="null"/>.
         /// </exception>
-        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, JaahasOtlpExporterOptions options) {
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, JaahasOtlpExporterOptions options) 
+            => builder.AddOtlpExporter(null, options);
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
+        /// options.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="TracerProviderBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <param name="options">
+        ///   The OTLP exporter options.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="TracerProviderBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, string? name, JaahasOtlpExporterOptions options) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(options);
@@ -130,7 +213,7 @@ namespace OpenTelemetry.Trace {
 #endif
 
             if (options.Enabled && options.Signals.HasFlag(OtlpExporterSignalKind.Traces)) {
-                builder.AddOtlpExporter(opts => OtlpExporterConfigurationUtilities.ConfigureOtlpExporterOptions(opts, options, OtlpExporterSignalKind.Traces));
+                builder.AddOtlpExporter(name, opts => OtlpExporterConfigurationUtilities.ConfigureOtlpExporterOptions(opts, options, OtlpExporterSignalKind.Traces));
             }
 
             return builder;

--- a/src/Jaahas.OpenTelemetry.Extensions/README.md
+++ b/src/Jaahas.OpenTelemetry.Extensions/README.md
@@ -163,3 +163,47 @@ services.AddOpenTelemetry()
 ```
 
 Jaeger's OTLP trace receivers listen on the standard OTLP exporter endpoints i.e. port 4317 for gRPC and port 4318 for HTTP/Protobuf. When the `Endpoint` setting is omitted from the configuration, the exporter will default to the standard port for the export format on `localhost`.
+
+
+## Configuring Multiple Exporters
+
+You can also configure multiple named exporters by providing a name to the `AddOtlpExporter` extension method. For example, if you wanted to export logs to Seq and traces to Jaeger:
+
+```csharp
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
+    // TODO: configure trace and metrics instrumentation.
+    .AddOtlpExporter("seq", 
+        configuration, 
+        configurationSectionName: "OpenTelemetry:Exporters:OTLP:Seq")
+    .AddOtlpExporter("jaeger", 
+        configuration, 
+        configurationSectionName: "OpenTelemetry:Exporters:OTLP:Jaeger");
+```
+
+You would then configure the exporters in your `appsettings.json` file as follows:
+
+```json
+{
+    "OpenTelemetry": {
+        "Exporters": {
+            "OTLP": {
+                "Seq": {
+                    "Enabled": true,
+                    "Protocol": "HttpProtobuf",
+                    "Endpoint": "http://localhost:5341/ingest/otlp",
+                    "Signals": "Logs",
+                    "Headers": {
+                        "X-Seq-ApiKey": "your-api-key"
+                    }
+                },
+                "Jaeger": {
+                    "Enabled": true,
+                    "Protocol": "HttpProtobuf",
+                    "Signals": "Traces"
+                }
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
This PR adds support for configuring multiple, named OTLP exporters, so that signals can be exported to multiple destinations if required. 

The underlying OpenTelemetry.Exporter.OpenTelemetryProtocol library already supports this, so it was just a case of adding new overloads to `AddOtlpExporter` that allow a name to be specified.

The PR also adds sample projects demonstrating how to configure a default OTLP exporter, and multiple named exporters.