### PR TITLE
Configure service using resource detector

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.11.1" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />

--- a/Jaahas.OpenTelemetry.sln
+++ b/Jaahas.OpenTelemetry.sln
@@ -27,9 +27,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{9EC8
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jaahas.OpenTelemetry.Extensions", "src\Jaahas.OpenTelemetry.Extensions\Jaahas.OpenTelemetry.Extensions.csproj", "{6DF95504-2089-4537-9C56-2414465BFCA0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultipleDestinationOtlpExporterExample", "samples\MultipleDestinationOtlpExporterExample\MultipleDestinationOtlpExporterExample.csproj", "{DF72DB5E-3376-4295-BD78-95C26B37433E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MultipleDestinationOtlpExporterExample", "samples\MultipleDestinationOtlpExporterExample\MultipleDestinationOtlpExporterExample.csproj", "{DF72DB5E-3376-4295-BD78-95C26B37433E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtlpExporterExample", "samples\OtlpExporterExample\OtlpExporterExample.csproj", "{BF201C92-6C05-431E-A805-FFF1A719356A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OtlpExporterExample", "samples\OtlpExporterExample\OtlpExporterExample.csproj", "{BF201C92-6C05-431E-A805-FFF1A719356A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jaahas.OpenTelemetry.Extensions.Tests", "test\Jaahas.OpenTelemetry.Extensions.Tests\Jaahas.OpenTelemetry.Extensions.Tests.csproj", "{15E6D07F-0159-4768-8826-42601BB59191}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResourceBuilderTest1", "test\ResourceBuilderTest1\ResourceBuilderTest1.csproj", "{25A30BD1-0495-4C44-B30E-16C442C60984}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResourceBuilderTest2", "test\ResourceBuilderTest2\ResourceBuilderTest2.csproj", "{9CEADFF6-05F6-4580-9DEF-8B5071BA7F78}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -49,6 +55,18 @@ Global
 		{BF201C92-6C05-431E-A805-FFF1A719356A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF201C92-6C05-431E-A805-FFF1A719356A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF201C92-6C05-431E-A805-FFF1A719356A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{15E6D07F-0159-4768-8826-42601BB59191}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15E6D07F-0159-4768-8826-42601BB59191}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15E6D07F-0159-4768-8826-42601BB59191}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{15E6D07F-0159-4768-8826-42601BB59191}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25A30BD1-0495-4C44-B30E-16C442C60984}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25A30BD1-0495-4C44-B30E-16C442C60984}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25A30BD1-0495-4C44-B30E-16C442C60984}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25A30BD1-0495-4C44-B30E-16C442C60984}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9CEADFF6-05F6-4580-9DEF-8B5071BA7F78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9CEADFF6-05F6-4580-9DEF-8B5071BA7F78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9CEADFF6-05F6-4580-9DEF-8B5071BA7F78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9CEADFF6-05F6-4580-9DEF-8B5071BA7F78}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -57,6 +75,9 @@ Global
 		{6DF95504-2089-4537-9C56-2414465BFCA0} = {10A2813D-C970-4F6F-9A59-94F7C972257F}
 		{DF72DB5E-3376-4295-BD78-95C26B37433E} = {9EC81ADF-5CE2-4140-96BC-958CB9E0365C}
 		{BF201C92-6C05-431E-A805-FFF1A719356A} = {9EC81ADF-5CE2-4140-96BC-958CB9E0365C}
+		{15E6D07F-0159-4768-8826-42601BB59191} = {ADFADB4B-0729-40E6-B241-6E1B89A8731C}
+		{25A30BD1-0495-4C44-B30E-16C442C60984} = {ADFADB4B-0729-40E6-B241-6E1B89A8731C}
+		{9CEADFF6-05F6-4580-9DEF-8B5071BA7F78} = {ADFADB4B-0729-40E6-B241-6E1B89A8731C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {94DF2EE3-033D-46CD-9EC3-7BC808B13372}

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 1,
+  "Minor": 2,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/samples/MultipleDestinationOtlpExporterExample/Program.cs
+++ b/samples/MultipleDestinationOtlpExporterExample/Program.cs
@@ -9,7 +9,7 @@ builder.Services.AddHostedService<Worker>();
 // Note that both exporters actually export to the same destination in this example, but they
 // export different signal types. See appsettings.json for the configuration.
 builder.Services.AddOpenTelemetry()
-    .ConfigureResource(resource => resource.AddService("MultipleDestinationOtlpExporterExample"))
+    .ConfigureResource(resource => resource.AddDefaultService())
     .AddOtlpExporter("seq-traces", builder.Configuration, "OpenTelemetry:Exporters:OTLP:SeqTraces")
     .AddOtlpExporter("seq-logs", builder.Configuration, "OpenTelemetry:Exporters:OTLP:SeqLogs")
     .WithTracing(tracing => tracing.AddSource(Worker.ActivitySourceName));

--- a/samples/OtlpExporterExample/Program.cs
+++ b/samples/OtlpExporterExample/Program.cs
@@ -7,7 +7,7 @@ var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddHostedService<Worker>();
 
 builder.Services.AddOpenTelemetry()
-    .ConfigureResource(resource => resource.AddService("OtlpExporterExample"))
+    .ConfigureResource(resource => resource.AddDefaultService())
     .AddOtlpExporter(builder.Configuration)
     .WithTracing(tracing => tracing.AddSource(Worker.ActivitySourceName));
 

--- a/src/Jaahas.OpenTelemetry.Extensions/OpenTelemetryServiceAttribute.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/OpenTelemetryServiceAttribute.cs
@@ -11,6 +11,11 @@
         /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// The namespace for the service.
+        /// </summary>
+        public string? Namespace { get; set; }
+
 
         /// <summary>
         /// Creates a new <see cref="OpenTelemetryServiceAttribute"/> instance.

--- a/src/Jaahas.OpenTelemetry.Extensions/OpenTelemetryServiceAttributeDetector.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/OpenTelemetryServiceAttributeDetector.cs
@@ -1,0 +1,65 @@
+﻿using System.Reflection;
+
+using OpenTelemetry.Resources;
+
+namespace Jaahas.OpenTelemetry {
+
+    /// <summary>
+    /// <see cref="IResourceDetector"/> that uses an <see cref="OpenTelemetryServiceAttribute"/> 
+    /// on an assembly to infer service information.
+    /// </summary>
+    /// <remarks>
+    ///   If the specified assembly is not annotated with an <see cref="OpenTelemetryServiceAttribute"/>, 
+    ///   the service name of the resource will be set to the name of the assembly.
+    /// </remarks>
+    internal class OpenTelemetryServiceAttributeDetector : IResourceDetector {
+
+        /// <summary>
+        /// The assembly.
+        /// </summary>
+        private readonly Assembly _assembly;
+
+        /// <summary>
+        /// The service instance identifier.
+        /// </summary>
+        private readonly string? _serviceInstanceId;
+
+
+        /// <summary>
+        /// Creates a new <see cref="OpenTelemetryServiceAttributeDetector"/> instance.
+        /// </summary>
+        /// <param name="assembly">
+        ///   The assembly to use to determine the service name and version.
+        /// </param>
+        /// <param name="serviceInstanceId">
+        ///   The optional unique identifier for the service instance. A service instance 
+        ///   identifier will be automatically generated if this value is <see langword="null"/> 
+        ///   or white space.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="assembly"/> is <see langword="null"/>.
+        /// </exception>
+        public OpenTelemetryServiceAttributeDetector(Assembly assembly, string? serviceInstanceId) {
+            _assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
+            _serviceInstanceId = string.IsNullOrWhiteSpace(serviceInstanceId)
+                ? null
+                : serviceInstanceId;
+        }
+
+
+        /// <inheritdoc/>
+        public Resource Detect() {
+            var attr = _assembly.GetCustomAttribute<OpenTelemetryServiceAttribute>();
+            var serviceName = attr?.Name ?? _assembly.GetName()?.Name ?? throw new InvalidOperationException("Unable to infer service name from assembly. The assembly must be annotated with an [OpenTelemetryService] attribute or it must define an assembly name.");
+
+            return ResourceBuilder.CreateDefault()
+                .AddService(
+                    serviceName,
+                    serviceNamespace: attr?.Namespace,
+                    serviceVersion: _assembly.GetName()?.Version?.ToString(3),
+                    serviceInstanceId: _serviceInstanceId)
+                .Build();
+        }
+
+    }
+}

--- a/src/Jaahas.OpenTelemetry.Extensions/README.md
+++ b/src/Jaahas.OpenTelemetry.Extensions/README.md
@@ -25,6 +25,13 @@ services.AddOpenTelemetry()
     .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly, "some-id"));
 ```
 
+If your entry assembly is annotated with an `[Jaahas.OpenTelemetry.OpenTelemetryService]` attribute you can also use the `AddDefaultService` extension method to simplify registration:
+
+```csharp
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddDefaultService());
+```
+
 
 # Configuring a Multi-Signal OpenTelemetry Protocol (OTLP) Exporter
 

--- a/test/Jaahas.OpenTelemetry.Extensions.Tests/Jaahas.OpenTelemetry.Extensions.Tests.csproj
+++ b/test/Jaahas.OpenTelemetry.Extensions.Tests/Jaahas.OpenTelemetry.Extensions.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Jaahas.OpenTelemetry.Extensions\Jaahas.OpenTelemetry.Extensions.csproj" />
+    <ProjectReference Include="..\ResourceBuilderTest1\ResourceBuilderTest1.csproj" />
+    <ProjectReference Include="..\ResourceBuilderTest2\ResourceBuilderTest2.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/test/Jaahas.OpenTelemetry.Extensions.Tests/ResourceBuilderTests.cs
+++ b/test/Jaahas.OpenTelemetry.Extensions.Tests/ResourceBuilderTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+
+using OpenTelemetry.Resources;
+
+namespace Jaahas.OpenTelemetry.Extensions.Tests {
+    [TestClass]
+    public class ResourceBuilderTests {
+
+        [TestMethod]
+        public void ShouldAddServiceFromEntryAssembly() {
+            var resource = ResourceBuilder.CreateEmpty()
+                .AddDefaultService()
+                .Build();
+
+            Assert.AreEqual(Assembly.GetEntryAssembly()!.GetName().Name, resource.Attributes.FirstOrDefault(x => x.Key == "service.name").Value as string);
+        }
+
+
+        [TestMethod]
+        public void ShouldAddServiceFromAnnotatedAssembly() {
+            var resource = ResourceBuilder.CreateEmpty()
+                .AddService(typeof(ResourceBuilderTest1.Constants).Assembly)
+                .Build();
+
+            Assert.AreEqual(ResourceBuilderTest1.Constants.ServiceName, resource.Attributes.FirstOrDefault(x => x.Key == "service.name").Value as string);
+        }
+
+
+        [TestMethod]
+        public void ShouldAddServiceFromUnannotatedAssembly() {
+            var resource = ResourceBuilder.CreateEmpty()
+                .AddService(typeof(ResourceBuilderTest2.Constants).Assembly)
+                .Build();
+
+            Assert.AreEqual(typeof(ResourceBuilderTest2.Constants).Assembly.GetName().Name, resource.Attributes.FirstOrDefault(x => x.Key == "service.name").Value as string);
+        }
+
+    }
+}

--- a/test/ResourceBuilderTest1/AssemblyAttributes.cs
+++ b/test/ResourceBuilderTest1/AssemblyAttributes.cs
@@ -1,0 +1,5 @@
+﻿using Jaahas.OpenTelemetry;
+
+using ResourceBuilderTest1;
+
+[assembly: OpenTelemetryService(Constants.ServiceName)]

--- a/test/ResourceBuilderTest1/Constants.cs
+++ b/test/ResourceBuilderTest1/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace ResourceBuilderTest1 {
+    public static class Constants {
+
+        public const string ServiceName = "unit-test-asm-1";
+
+    }
+}

--- a/test/ResourceBuilderTest1/ResourceBuilderTest1.csproj
+++ b/test/ResourceBuilderTest1/ResourceBuilderTest1.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Jaahas.OpenTelemetry.Extensions\Jaahas.OpenTelemetry.Extensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/ResourceBuilderTest2/Constants.cs
+++ b/test/ResourceBuilderTest2/Constants.cs
@@ -1,0 +1,4 @@
+﻿namespace ResourceBuilderTest2 {
+    public static class Constants {
+  }
+}

--- a/test/ResourceBuilderTest2/ResourceBuilderTest2.csproj
+++ b/test/ResourceBuilderTest2/ResourceBuilderTest2.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This PR adds a new `IResourceDetector` that is used to configure the OpenTelemetry service information using an `[OpenTelemetryService]` assembly annotation. The original logic from the `AddService` extension methods has been moved to the detector implementation.

A new `AddDefaultService` extension method has also been added, which is the equivalent to calling `AddService(Assembly.GetEntryAssembly())`.

Finally, the PR adds resource builder unit tests.