### PR TITLE
Service name semantic conventions

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 2,
+  "Minor": 3,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryResourceBuilderExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryResourceBuilderExtensions.cs
@@ -43,8 +43,7 @@ namespace OpenTelemetry.Resources {
         ///     <see cref="AssemblyName.Name"/> property is used as the service name.
         ///   </item>
         ///   <item>
-        ///     If neither of the above conditions are met, an <see cref="InvalidOperationException"/> is 
-        ///     thrown when the resource is built.
+        ///     If neither of the above conditions are met, the service name will be <c>unknown_service</c>.
         ///   </item>
         /// </list>
         /// 
@@ -98,8 +97,9 @@ namespace OpenTelemetry.Resources {
         ///     <see cref="AssemblyName.Name"/> property is used as the service name.
         ///   </item>
         ///   <item>
-        ///     If neither of the above conditions are met, an <see cref="InvalidOperationException"/> is 
-        ///     thrown when the resource is built.
+        ///     If neither of the above conditions are met, the service name will be <c>unknown_service:{entry_assembly_name}</c> 
+        ///     if <see cref="Assembly.GetEntryAssembly"/> has a non-<see langword="null"/> name, 
+        ///     or <c>unknown_service</c> otherwise.
         ///   </item>
         /// </list>
         /// 
@@ -163,8 +163,9 @@ namespace OpenTelemetry.Resources {
         ///     <see cref="AssemblyName.Name"/> property is used as the service name.
         ///   </item>
         ///   <item>
-        ///     If neither of the above conditions are met, an <see cref="InvalidOperationException"/> is 
-        ///     thrown when the resource is built.
+        ///     If neither of the above conditions are met, the service name will be <c>unknown_service:{entry_assembly_name}</c> 
+        ///     if <see cref="Assembly.GetEntryAssembly"/> has a non-<see langword="null"/> name, 
+        ///     or <c>unknown_service</c> otherwise.
         ///   </item>
         /// </list>
         /// 

--- a/src/Jaahas.OpenTelemetry.Extensions/OpenTelemetryServiceAttributeDetector.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/OpenTelemetryServiceAttributeDetector.cs
@@ -50,11 +50,17 @@ namespace Jaahas.OpenTelemetry {
         /// <inheritdoc/>
         public Resource Detect() {
             var attr = _assembly.GetCustomAttribute<OpenTelemetryServiceAttribute>();
-            var serviceName = attr?.Name ?? _assembly.GetName()?.Name ?? throw new InvalidOperationException("Unable to infer service name from assembly. The assembly must be annotated with an [OpenTelemetryService] attribute or it must define an assembly name.");
+            var serviceName = attr?.Name ?? _assembly.GetName()?.Name;
+            if (string.IsNullOrWhiteSpace(serviceName)) {
+                var entryAssemblyName = Assembly.GetEntryAssembly()?.GetName()?.Name;
+                serviceName = string.IsNullOrWhiteSpace(entryAssemblyName)
+                    ? "unknown_service"
+                    : $"unknown_service:{entryAssemblyName}";
+            }
 
             return ResourceBuilder.CreateDefault()
                 .AddService(
-                    serviceName,
+                    serviceName!,
                     serviceNamespace: attr?.Namespace,
                     serviceVersion: _assembly.GetName()?.Version?.ToString(3),
                     serviceInstanceId: _serviceInstanceId)


### PR DESCRIPTION
This PR modifies `OpenTelemetryServiceAttributeDetector` to follow [semantic conventions for services](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service) and set the name to either `unknown_service` or `unknown_service:{entry_assembly_name}` if a name cannot be otherwise inferred.