### PR TITLE
Combine IConfiguration and callback when configuring exporter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ The default configuration used is as follows:
 
 Note that the default configuration means that the OTLP exporter is disabled by default and calls to the `AddOtlpExporter` extension method have no effect until it is enabled.
 
-It is also possible to configure the exporter by providing your own `JaahasOtlpExporterOptions` instance, or by providing an `Action<JaahasOtlpExporterOptions>` that can be used to configure the options:
+
+## Manually Specifying Options
+
+You can configure the exporter by manually providing a `JaahasOtlpExporterOptions` if preferred:
 
 ```csharp
 // Configure exporter options manually.
@@ -119,6 +122,12 @@ services.AddOpenTelemetry()
     .AddOtlpExporter(exporterOptions);
 ```
 
+
+## Configuring Options via Callback
+
+You can also configure the exporter by providing an `Action<JaahasOtlpExporterOptions>` that can be used to configure the options:
+
+
 ```csharp
 // Configure exporter options manually via callback.
 
@@ -130,6 +139,38 @@ services.AddOpenTelemetry()
         exporterOptions.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
         exporterOptions.Signals = OtlpExporterSignalKind.TracesAndLogs;
     });
+```
+
+
+## Combining Configuration and Callbacks
+
+You can also specify a delegate to configure the options after the configuration section has been bound:
+
+```csharp
+// Bind configuration and then update via callback.
+
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
+    // TODO: configure trace and metrics instrumentation.
+    .AddOtlpExporter(configuration, configure: exporterOptions => {
+        exporterOptions.Enabled = true;
+    });
+```
+
+
+## Using `IConfigureOptions<T>`, `IConfigureNamedOptions<T>` or `IPostConfigureOptions<T>`
+
+You can register a custom `IConfigureOptions<JaahasOtlpExporterOptions>`, `IConfigureNamedOptions<JaahasOtlpExporterOptions>` or `IPostConfigureOptions<JaahasOtlpExporterOptions>` as a singleton service to configure or override the exporter options. This is useful when you need to perform more complex configuration that cannot be achieved via the configuration system alone.
+
+```csharp
+// Perform configuration via IPostConfigureOptions<T>.
+
+services.AddSingleton<IPostConfigureOptions<JaahasOtlpExporterOptions>, MyPostConfigureOptions>();
+
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
+    // TODO: configure trace and metrics instrumentation.
+    .AddOtlpExporter();
 ```
 
 
@@ -193,7 +234,7 @@ services.AddOpenTelemetry()
         configurationSectionName: "OpenTelemetry:Exporters:OTLP:Jaeger");
 ```
 
-You would then configure the exporters in your `appsettings.json` file as follows:
+You could then configure the exporters in your `appsettings.json` file as follows:
 
 ```json
 {

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 3,
+  "Minor": 4,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryBuilderExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryBuilderExtensions.cs
@@ -15,6 +15,73 @@ namespace OpenTelemetry {
     public static class JaahasOpenTelemetryBuilderExtensions {
 
         /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that uses the default configuration.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="OpenTelemetryBuilder"/> to configure.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///   
+        /// <para>
+        ///   The default configuration does not enable the OTLP exporter. You should use an 
+        ///   <see cref="Microsoft.Extensions.Options.IConfigureOptions{TOptions}"/>,
+        ///   <see cref="Microsoft.Extensions.Options.IConfigureNamedOptions{TOptions}"/> or 
+        ///   <see cref="Microsoft.Extensions.Options.IPostConfigureOptions{TOptions}"/> to 
+        ///   explicitly enable the exporter when calling this overload.
+        /// </para>
+        /// 
+        /// <para>
+        ///   If the OLTP exporter is enabled, the exporter is automatically registered 
+        ///   for each signal that it is enabled for (traces, logs, and metrics).
+        /// </para>
+        /// 
+        /// </remarks>
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder)
+            => builder.AddOtlpExporter(null, _ => { });
+
+
+        /// <summary>
+        /// Adds an OpenTelemetry Protocol (OTLP) exporter that uses the default configuration.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="OpenTelemetryBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        ///   The name for the OTLP exporter configuration.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="OpenTelemetryBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///   
+        /// <para>
+        ///   The default configuration does not enable the OTLP exporter. You should use an 
+        ///   <see cref="Microsoft.Extensions.Options.IConfigureOptions{TOptions}"/>,
+        ///   <see cref="Microsoft.Extensions.Options.IConfigureNamedOptions{TOptions}"/> or 
+        ///   <see cref="Microsoft.Extensions.Options.IPostConfigureOptions{TOptions}"/> to 
+        ///   explicitly enable the exporter when calling this overload.
+        /// </para>
+        /// 
+        /// <para>
+        ///   If the OLTP exporter is enabled, the exporter is automatically registered 
+        ///   for each signal that it is enabled for (traces, logs, and metrics).
+        /// </para>
+        /// 
+        /// </remarks>
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, string? name)
+            => builder.AddOtlpExporter(name, _ => { });
+
+
+        /// <summary>
         /// Adds an OpenTelemetry Protocol (OTLP) exporter that is configured using the provided 
         /// <paramref name="configuration"/>.
         /// </summary>
@@ -28,6 +95,10 @@ namespace OpenTelemetry {
         ///   The configuration section to bind the OTLP exporter configuration from. Specify 
         ///   <see langword="null"/> or white space to bind directly against the root of the 
         ///   <paramref name="configuration"/>.
+        /// </param>
+        /// <param name="configure">
+        ///   An optional delegate used to further configure the OTLP exporter options after 
+        ///   binding the configuration section.
         /// </param>
         /// <returns>
         ///   The updated <see cref="OpenTelemetryBuilder"/>.
@@ -54,8 +125,8 @@ namespace OpenTelemetry {
         /// </para>
         /// 
         /// </remarks>
-        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) 
-            => builder.AddOtlpExporter(null, configuration, configurationSectionName);
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection, Action<JaahasOtlpExporterOptions>? configure = null) 
+            => builder.AddOtlpExporter(null, configuration, configurationSectionName, configure);
 
 
         /// <summary>
@@ -76,6 +147,10 @@ namespace OpenTelemetry {
         ///   <see langword="null"/> or white space to bind directly against the root of the 
         ///   <paramref name="configuration"/>.
         /// </param>
+        /// <param name="configure">
+        ///   An optional delegate used to further configure the OTLP exporter options after 
+        ///   binding the configuration section.
+        /// </param>
         /// <returns>
         ///   The updated <see cref="OpenTelemetryBuilder"/>.
         /// </returns>
@@ -101,7 +176,7 @@ namespace OpenTelemetry {
         /// </para>
         /// 
         /// </remarks>
-        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        public static OpenTelemetryBuilder AddOtlpExporter(this OpenTelemetryBuilder builder, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection, Action<JaahasOtlpExporterOptions>? configure = null) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configuration);
@@ -118,7 +193,10 @@ namespace OpenTelemetry {
                 ? configuration
                 : configuration.GetSection(configurationSectionName!);
 
-            return builder.AddOtlpExporter(name, options => OtlpExporterConfigurationUtilities.Bind(options, configurationSection));
+            return builder.AddOtlpExporter(name, options => {
+                OtlpExporterConfigurationUtilities.Bind(options, configurationSection);
+                configure?.Invoke(options);
+            });
         }
 
 

--- a/src/Jaahas.OpenTelemetry.Extensions/README.md
+++ b/src/Jaahas.OpenTelemetry.Extensions/README.md
@@ -47,7 +47,7 @@ services.AddOpenTelemetry()
     .AddOtlpExporter(configuration);
 ```
 
-By default, the `AddOtlpExporter` extension method will bind against a configuration section named `OpenTelemetry:Exporters:OTLP` to configure an instance of [JaahasOtlpExporterOptions](./Exporters/OpenTelemetryProtocol/JaahasOtlpExporterOptions.cs).
+By default, the `AddOtlpExporter` extension method will bind against a configuration section named `OpenTelemetry:Exporters:OTLP` to configure an instance of `JaahasOtlpExporterOptions`.
 
 The default configuration used is as follows:
 
@@ -97,7 +97,10 @@ The default configuration used is as follows:
 
 Note that the default configuration means that the OTLP exporter is disabled by default and calls to the `AddOtlpExporter` extension method have no effect until it is enabled.
 
-It is also possible to configure the exporter by providing your own `JaahasOtlpExporterOptions` instance, or by providing an `Action<JaahasOtlpExporterOptions>` that can be used to configure the options:
+
+## Manually Specifying Options
+
+You can configure the exporter by manually providing a `JaahasOtlpExporterOptions` if preferred:
 
 ```csharp
 // Configure exporter options manually.
@@ -114,6 +117,12 @@ services.AddOpenTelemetry()
     .AddOtlpExporter(exporterOptions);
 ```
 
+
+## Configuring Options via Callback
+
+You can also configure the exporter by providing an `Action<JaahasOtlpExporterOptions>` that can be used to configure the options:
+
+
 ```csharp
 // Configure exporter options manually via callback.
 
@@ -125,6 +134,38 @@ services.AddOpenTelemetry()
         exporterOptions.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
         exporterOptions.Signals = OtlpExporterSignalKind.TracesAndLogs;
     });
+```
+
+
+## Combining Configuration and Callbacks
+
+You can also specify a delegate to configure the options after the configuration section has been bound:
+
+```csharp
+// Bind configuration and then update via callback.
+
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
+    // TODO: configure trace and metrics instrumentation.
+    .AddOtlpExporter(configuration, configure: exporterOptions => {
+        exporterOptions.Enabled = true;
+    });
+```
+
+
+## Using `IConfigureOptions<T>`, `IConfigureNamedOptions<T>` or `IPostConfigureOptions<T>`
+
+You can register a custom `IConfigureOptions<JaahasOtlpExporterOptions>`, `IConfigureNamedOptions<JaahasOtlpExporterOptions>` or `IPostConfigureOptions<JaahasOtlpExporterOptions>` as a singleton service to configure or override the exporter options. This is useful when you need to perform more complex configuration that cannot be achieved via the configuration system alone.
+
+```csharp
+// Perform configuration via IPostConfigureOptions<T>.
+
+services.AddSingleton<IPostConfigureOptions<JaahasOtlpExporterOptions>, MyPostConfigureOptions>();
+
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
+    // TODO: configure trace and metrics instrumentation.
+    .AddOtlpExporter();
 ```
 
 


### PR DESCRIPTION
This PR modifies the overloads of `AddOtlpExporter` that accept an `IConfiguration` parameter to also allow an optional `Action<JaahasOtlpExporterOptions>` to be specified to perform additional configuration after the configuration section has been bound.

It also adds new `AddOtlpExporter` extensions that allow a default or named `JaahasOtlpExporterOptions` to be registered using default settings.