### PR TITLE
Add multiple OTLP exporters from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,19 @@ You could then configure the exporters in your `appsettings.json` file as follow
 }
 ```
 
+Alternatively, you can also use the `AddNamedOtlpExporters` extension method to automatically configure a named exporter for every child section found in a given configuration section:
+
+```csharp
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
+    // TODO: configure trace and metrics instrumentation.
+    .AddNamedOtlpExporters(
+        configuration, 
+        configurationSectionName: "OpenTelemetry:Exporters:OTLP"));
+```
+
+This approach is particularly useful when the number and names of the exporters is not known at compile time, as it allows additional exporters to be added solely via a configuration change.
+
 
 # Building the Solution
 

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 4,
+  "Minor": 5,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/samples/MultipleDestinationOtlpExporterExample/Program.cs
+++ b/samples/MultipleDestinationOtlpExporterExample/Program.cs
@@ -10,8 +10,7 @@ builder.Services.AddHostedService<Worker>();
 // export different signal types. See appsettings.json for the configuration.
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(resource => resource.AddDefaultService())
-    .AddOtlpExporter("seq-traces", builder.Configuration, "OpenTelemetry:Exporters:OTLP:SeqTraces")
-    .AddOtlpExporter("seq-logs", builder.Configuration, "OpenTelemetry:Exporters:OTLP:SeqLogs")
+    .AddNamedOtlpExporters(builder.Configuration)
     .WithTracing(tracing => tracing.AddSource(Worker.ActivitySourceName));
 
 var host = builder.Build();

--- a/src/Jaahas.OpenTelemetry.Extensions/README.md
+++ b/src/Jaahas.OpenTelemetry.Extensions/README.md
@@ -255,3 +255,16 @@ You would then configure the exporters in your `appsettings.json` file as follow
     }
 }
 ```
+
+Alternatively, you can also use the `AddNamedOtlpExporters` extension method to automatically configure a named exporter for every child section found in a given configuration section:
+
+```csharp
+services.AddOpenTelemetry()
+    .ConfigureResource(builder => builder.AddService(typeof(MyType).Assembly))
+    // TODO: configure trace and metrics instrumentation.
+    .AddNamedOtlpExporters(
+        configuration, 
+        configurationSectionName: "OpenTelemetry:Exporters:OTLP"));
+```
+
+This approach is particularly useful when the number and names of the exporters is not known at compile time, as it allows additional exporters to be added solely via a configuration change.


### PR DESCRIPTION
This PR adds a new `AddNamedOtlpExporters` extension to `OpenTelemetryBuilder` that allows multiple named OTLP exporters to be registered by providing a root configuration section containing the named exporter configurations.

The extension will iterate over the child sections for the provided configuration section and register one exporter per child section. For example, calling `AddNamedOtlpExporters` and specifying the following configuration would automatically register named OTLP exporters called "Seq" and "Jaeger":

```json
{
  "OpenTelemetry": {
    "Exporters": {
      "OTLP": {
        "Seq": {
          "Enabled": true,
          "Protocol": "HttpProtobuf",
          "Endpoint": "https://my-seq-server/ingest/otlp",
          "Signals": "TracesAndLogs",
          "Headers": {
            "X-Seq-ApiKey": "my-api-key"
          }
        },
        "Jaeger": {
          "Enabled": true,
          "Protocol": "HttpProtobuf",
          "Signals": "Traces"
        }
      }
    }
  }
}
```

This is useful when you want the ability to add or remove OTLP destinations via configuration without requiring a recompilation of your application.