### PR TITLE
Update to OpenTelemetry 1.11.0-rc.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0-rc.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.0-rc.1" />
   </ItemGroup>
 </Project>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 5,
+  "Minor": 6,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/src/Jaahas.OpenTelemetry.Extensions/OpenTelemetryServiceAttribute.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/OpenTelemetryServiceAttribute.cs
@@ -1,7 +1,7 @@
 ﻿namespace Jaahas.OpenTelemetry {
 
     /// <summary>
-    /// Marks an assembly as definint an OpenTelemetry service.
+    /// Marks an assembly as defining an OpenTelemetry service.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly)]
     public sealed class OpenTelemetryServiceAttribute : Attribute {


### PR DESCRIPTION
This PR updates the OpenTelemetry packages to v1.11.0-rc.1. This is particularly beneficial for the OTLP exporter package as it no longer has underlying dependencies on Google.Protobuf, Grpc.Core and so on.