### PR TITLE
Update OpenTelemetry packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,13 +8,16 @@
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.11.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.12.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.1" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0-rc.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.0-rc.1" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
   </ItemGroup>
 </Project>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
   "Minor": 7,
-  "Patch": 0,
+  "Patch": 1,
   "PreRelease": ""
 }


### PR DESCRIPTION
This PR updates OpenTelemetry package references from v1.11 pre-release versions to v1.11.1.