### PR TITLE
New extensions and defaults

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="MSTest" Version="3.8.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The default configuration used is as follows:
                 "Enabled": false,
 
                 // Protocol can be "Grpc" or "HttpProtobuf".
-                "Protocol": "Grpc",
+                "Protocol": "HttpProtobuf",
 
                 // Endpoint is inferred from the export protocol if not 
                 // specified.

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
-  "Major": 2,
-  "Minor": 7,
-  "Patch": 1,
+  "Major": 3,
+  "Minor": 0,
+  "Patch": 0,
   "PreRelease": ""
 }

--- a/src/Jaahas.OpenTelemetry.Extensions/Exporters/OpenTelemetryProtocol/JaahasOtlpExporterOptions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/Exporters/OpenTelemetryProtocol/JaahasOtlpExporterOptions.cs
@@ -15,7 +15,7 @@ namespace Jaahas.OpenTelemetry.Exporters.OpenTelemetryProtocol {
         /// <summary>
         /// The OTLP exporter protocol to use.
         /// </summary>
-        public OtlpExportProtocol Protocol { get; set; } = OtlpExportProtocol.Grpc;
+        public OtlpExportProtocol Protocol { get; set; } = OtlpExportProtocol.HttpProtobuf;
 
         /// <summary>
         /// The endpoint that the exporter should send data to.

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryBuilderExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryBuilderExtensions.cs
@@ -361,15 +361,15 @@ namespace OpenTelemetry {
             }
 
             if (options.Signals.HasFlag(OtlpExporterSignalKind.Traces)) {
-                builder.WithTracing(builder => builder.AddOtlpExporter(name, options));
+                builder.WithTracing(traces => traces.AddOtlpExporter(name, options));
             }
             if (options.Signals.HasFlag(OtlpExporterSignalKind.Metrics)) {
-                builder.WithMetrics(builder => builder.AddOtlpExporter(name, options));
+                builder.WithMetrics(metrics => metrics.AddOtlpExporter(name, options));
             }
             if (options.Signals.HasFlag(OtlpExporterSignalKind.Logs)) {
-                builder.WithLogging(configureBuilder: null, configureOptions: builder => {
-                    builder.IncludeScopes = true;
-                    builder.AddOtlpExporter(name, options);
+                builder.WithLogging(configureBuilder: null, configureOptions: logging => {
+                    logging.IncludeScopes = true;
+                    logging.AddOtlpExporter(name, options);
                 });
             }
 
@@ -477,7 +477,7 @@ namespace OpenTelemetry {
                     configurationSectionName: null, 
                     configure: configure == null 
                         ? null 
-                        : options => configure?.Invoke(name, options));
+                        : options => configure.Invoke(name, options));
             }
 
             return builder;

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryLogExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryLogExtensions.cs
@@ -23,6 +23,10 @@ namespace OpenTelemetry.Logs {
         ///   <see langword="null"/> or white space to bind directly against the root of the 
         ///   <paramref name="configuration"/>.
         /// </param>
+        /// <param name="configure">
+        ///   An optional delegate used to further configure the OTLP exporter options after 
+        ///   binding the configuration section.
+        /// </param>
         /// <returns>
         ///   The updated <see cref="OpenTelemetryLoggerOptions"/>.
         /// </returns>
@@ -32,8 +36,8 @@ namespace OpenTelemetry.Logs {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configuration"/> is <see langword="null"/>.
         /// </exception>
-        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) 
-            => loggerOptions.AddOtlpExporter(null, configuration, configurationSectionName);
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection, Action<JaahasOtlpExporterOptions>? configure = null) 
+            => loggerOptions.AddOtlpExporter(null, configuration, configurationSectionName, configure);
 
 
         /// <summary>
@@ -53,6 +57,10 @@ namespace OpenTelemetry.Logs {
         ///   <see langword="null"/> or white space to bind directly against the root of the 
         ///   <paramref name="configuration"/>.
         /// </param>
+        /// <param name="configure">
+        ///   An optional delegate used to further configure the OTLP exporter options after 
+        ///   binding the configuration section.
+        /// </param>
         /// <returns>
         ///   The updated <see cref="OpenTelemetryLoggerOptions"/>.
         /// </returns>
@@ -62,7 +70,7 @@ namespace OpenTelemetry.Logs {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configuration"/> is <see langword="null"/>.
         /// </exception>
-        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection, Action<JaahasOtlpExporterOptions>? configure = null) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(loggerOptions);
             ArgumentNullException.ThrowIfNull(configuration);
@@ -81,6 +89,7 @@ namespace OpenTelemetry.Logs {
                 : configuration.GetSection(configurationSectionName!);
 
             OtlpExporterConfigurationUtilities.Bind(options, configurationSection);
+            configure?.Invoke(options);
 
             return loggerOptions.AddOtlpExporter(name, options);
         }

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryMetricExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryMetricExtensions.cs
@@ -24,6 +24,10 @@ namespace OpenTelemetry.Metrics {
         ///   <see langword="null"/> or white space to bind directly against the root of the 
         ///   <paramref name="configuration"/>.
         /// </param>
+        /// <param name="configure">
+        ///   An optional delegate used to further configure the OTLP exporter options after 
+        ///   binding the configuration section.
+        /// </param>
         /// <returns>
         ///   The updated <see cref="MeterProviderBuilder"/>.
         /// </returns>
@@ -33,8 +37,8 @@ namespace OpenTelemetry.Metrics {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configuration"/> is <see langword="null"/>.
         /// </exception>
-        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection)
-            => builder.AddOtlpExporter(null, configuration, configurationSectionName);
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection, Action<JaahasOtlpExporterOptions>? configure = null)
+            => builder.AddOtlpExporter(null, configuration, configurationSectionName, configure);
 
 
         /// <summary>
@@ -55,6 +59,10 @@ namespace OpenTelemetry.Metrics {
         ///   <see langword="null"/> or white space to bind directly against the root of the 
         ///   <paramref name="configuration"/>.
         /// </param>
+        /// <param name="configure">
+        ///   An optional delegate used to further configure the OTLP exporter options after 
+        ///   binding the configuration section.
+        /// </param>
         /// <returns>
         ///   The updated <see cref="MeterProviderBuilder"/>.
         /// </returns>
@@ -64,7 +72,7 @@ namespace OpenTelemetry.Metrics {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configuration"/> is <see langword="null"/>.
         /// </exception>
-        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection, Action<JaahasOtlpExporterOptions>? configure = null) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configuration);
@@ -84,7 +92,8 @@ namespace OpenTelemetry.Metrics {
                 : configuration.GetSection(configurationSectionName!);
 
             OtlpExporterConfigurationUtilities.Bind(options, configurationSection);
-
+            configure?.Invoke(options);
+            
             return builder.AddOtlpExporter(name, options);
         }
 

--- a/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryTraceExtensions.cs
+++ b/src/Jaahas.OpenTelemetry.Extensions/JaahasOpenTelemetryTraceExtensions.cs
@@ -27,6 +27,10 @@ namespace OpenTelemetry.Trace {
         ///   <see langword="null"/> or white space to bind directly against the root of the 
         ///   <paramref name="configuration"/>.
         /// </param>
+        /// <param name="configure">
+        ///   An optional delegate used to further configure the OTLP exporter options after 
+        ///   binding the configuration section.
+        /// </param>
         /// <returns>
         ///   The updated <see cref="TracerProviderBuilder"/>.
         /// </returns>
@@ -36,8 +40,8 @@ namespace OpenTelemetry.Trace {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configuration"/> is <see langword="null"/>.
         /// </exception>
-        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) 
-            => builder.AddOtlpExporter(null, configuration, configurationSectionName);
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection, Action<JaahasOtlpExporterOptions>? configure = null) 
+            => builder.AddOtlpExporter(null, configuration, configurationSectionName, configure);
 
 
         /// <summary>
@@ -58,6 +62,10 @@ namespace OpenTelemetry.Trace {
         ///   <see langword="null"/> or white space to bind directly against the root of the 
         ///   <paramref name="configuration"/>.
         /// </param>
+        /// <param name="configure">
+        ///   An optional delegate used to further configure the OTLP exporter options after 
+        ///   binding the configuration section.
+        /// </param>
         /// <returns>
         ///   The updated <see cref="TracerProviderBuilder"/>.
         /// </returns>
@@ -67,7 +75,7 @@ namespace OpenTelemetry.Trace {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="configuration"/> is <see langword="null"/>.
         /// </exception>
-        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection) {
+        public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, string? name, IConfiguration configuration, string? configurationSectionName = OtlpExporterConfigurationUtilities.DefaultOtlpExporterConfigurationSection, Action<JaahasOtlpExporterOptions>? configure = null) {
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configuration);
@@ -87,6 +95,7 @@ namespace OpenTelemetry.Trace {
                 : configuration.GetSection(configurationSectionName!);
 
             OtlpExporterConfigurationUtilities.Bind(options, configurationSection);
+            configure?.Invoke(options);
 
             return builder.AddOtlpExporter(name, options);
         }

--- a/src/Jaahas.OpenTelemetry.Extensions/README.md
+++ b/src/Jaahas.OpenTelemetry.Extensions/README.md
@@ -60,7 +60,7 @@ The default configuration used is as follows:
                 "Enabled": false,
 
                 // Protocol can be "Grpc" or "HttpProtobuf".
-                "Protocol": "Grpc",
+                "Protocol": "HttpProtobuf",
 
                 // Endpoint is inferred from the export protocol if not 
                 // specified.


### PR DESCRIPTION
## ⚠️ Breaking Changes

This PR contains the following breaking changes:
- The default value of `JaahasOtlpExporterOptions.Protocol` has been changed from `Grpc` to `HttpProtobuf`.
- The `AddOtlpExporter` extensions for `TracerProviderBuilder`, `MeterProviderBuilder` and `OpenTelemetryLoggerOptions` extensions that accept `IConfiguration` parameters have been extended to allow an optional delegate for performing further configuration to be specified in addition to the configuration object.